### PR TITLE
fix flush issue

### DIFF
--- a/www/js/controllers.js
+++ b/www/js/controllers.js
@@ -42,7 +42,7 @@ angular.module('testapp.controllers', [])
     };
 
     $scope.flush = function() {
-      mixpanel.flush('flush',
+      mixpanel.flush(
         function(what) {
           console.log('success flush');
         }, function(fail) {


### PR DESCRIPTION
Sending a string in flush() call is not correct following [cordova-mixpanel-plugin](https://github.com/samzilverberg/cordova-mixpanel-plugin#usage) docs. It fails when cordova tries to call apply(), as it finds a string instead of a callback function.
